### PR TITLE
Add Rust scaffolding to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,3 +123,6 @@ set(PROJECT_EXPORT_SET RippleExports)
 include(RippledCore)
 include(RippledInstall)
 include(RippledValidatorKeys)
+
+find_package(Cargo)
+add_subdirectory(src/rust)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "xrpl"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -67,3 +67,37 @@ git-subtree. See those directories' README files for more details.
 * [Clio API Server for the XRP Ledger](https://github.com/XRPLF/clio)
 * [Mailing List for Release Announcements](https://groups.google.com/g/ripple-server)
 * [Learn more about the XRP Ledger (YouTube)](https://www.youtube.com/playlist?list=PLJQ55Tj1hIVZtJ_JdTvSum2qMTsedWkNi)
+
+## Rust Build
+
+### Building the Rust Library
+
+To build the Rust library, you need to have Rust and Cargo installed. You can follow the instructions on the [official Rust website](https://www.rust-lang.org/tools/install) to install Rust and Cargo.
+
+Once you have Rust and Cargo installed, you can build the Rust library by running the following command in the root directory of the repository:
+
+```sh
+cargo build
+```
+
+This will compile the Rust library and generate the necessary artifacts.
+
+### Running the Rust Library
+
+To run the Rust library, you can use the following command:
+
+```sh
+cargo run
+```
+
+This will execute the main entry point of the Rust library and display the output.
+
+### Testing the Rust Library
+
+To run the tests for the Rust library, you can use the following command:
+
+```sh
+cargo test
+```
+
+This will execute the test cases defined in the Rust library and display the test results.

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,6 +32,7 @@ class Xrpl(ConanFile):
         'soci/4.0.3',
         'xxhash/0.8.2',
         'zlib/1.2.13',
+        'rust/1.56.0',  # Added Rust dependency
     ]
 
     tool_requires = [
@@ -173,6 +174,7 @@ class Xrpl(ConanFile):
             'sqlite3::sqlite',
             'xxhash::xxhash',
             'zlib::zlib',
+            'rust::rust',  # Added Rust dependency
         ]
         if self.options.rocksdb:
             libxrpl.requires.append('rocksdb::librocksdb')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn hello() -> String {
+    "Hello, world!".to_string()
+}

--- a/src/rust/CMakeLists.txt
+++ b/src/rust/CMakeLists.txt
@@ -1,0 +1,7 @@
+# CMakeLists.txt for building the Rust library
+
+find_package(Cargo REQUIRED)
+
+add_custom_target(rustlib ALL
+    COMMAND cargo build --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml
+)


### PR DESCRIPTION
Fixes #1

Add Rust scaffolding to the repository.

* **Cargo.toml and src/lib.rs**
  - Add `Cargo.toml` to define the Rust project and its dependencies.
  - Add `src/lib.rs` with a simple function `pub fn hello() -> String { "Hello, world!".to_string() }`.

* **CMakeLists.txt**
  - Modify `CMakeLists.txt` to include Rust support by adding `find_package(Cargo)` and `add_subdirectory(src/rust)`.

* **src/rust/CMakeLists.txt**
  - Add `src/rust/CMakeLists.txt` to build the Rust library using CMake.
  - Add `find_package(Cargo REQUIRED)` and `add_custom_target(rustlib ALL COMMAND cargo build --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml)`.

* **conanfile.py**
  - Modify `conanfile.py` to include Rust dependencies in the `requires` list.
  - Ensure Rust dependencies are installed during the build process.

* **README.md**
  - Update `README.md` to include instructions for building, running, and testing the Rust library.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enriquesantosblanco/rippled/issues/1?shareId=e1878dac-0140-41fa-957c-5fd6859d88a6).